### PR TITLE
IN-633 Specify the number of fractional seconds to include in the timestamp

### DIFF
--- a/lib/activesupport/taggedlogging/formatter.rb
+++ b/lib/activesupport/taggedlogging/formatter.rb
@@ -28,7 +28,7 @@ module ActiveSupport
         else
           data['message'] = message
         end
-        data['timestamp'] = timestamp.iso8601
+        data['timestamp'] = timestamp.iso8601(6)
 
         data.merge!(user_defined_attributes)
 


### PR DESCRIPTION
The default behavior of the `iso8601` function is to include no sub-second information because the default value for its `fraction_digits` argument is 0. See documentation [here](http://ruby-doc.org/stdlib-2.1.1/libdoc/time/rdoc/Time.html#method-i-xmlschema). 

Here is an example of the behavior:
```ruby
irb(main):001:0> require 'time'
require 'time'
=> true
irb(main):002:0> t = Time.now
t = Time.now
=> 2018-03-06 10:43:53 -0800
irb(main):003:0> t.iso8601
t.iso8601
=> "2018-03-06T10:43:53-08:00"
irb(main):004:0> t.iso8601(6)
t.iso8601(6)
=> "2018-03-06T10:43:53.403395-08:00"
```

I'm using a value of 6 for `fraction_digits` because that's the highest level Loggly will support [according to their documentation](https://www.loggly.com/docs/automated-parsing/#json)